### PR TITLE
Dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+i_*
 *.o
 src/fk/bessel.f
 src/fk/fk

--- a/Glib/run_fk.pl
+++ b/Glib/run_fk.pl
@@ -47,7 +47,6 @@ foreach my $fname (@config){
     print OUT "$pars{'MODEL'}\n";
     chdir $model or die;
     foreach my $depth (@depth) {
-        $depth = "0$depth" if ($depth < 10);
         if ($flat eq "YES") {
             # 计算双力偶
             system "fk.pl -M$model/$depth/f -N$nt/$dt -S2 @dist";

--- a/Glib/run_fk.pl
+++ b/Glib/run_fk.pl
@@ -18,18 +18,34 @@ foreach my $fname (@config){
     my $flat = "YES";
     $flat = $pars{"FLAT"} if defined($pars{"FLAT"});
 
-    mkdir $model unless (-d $model);
-    open (OUT, "> $model/$model") or die;
-    print OUT "$pars{'MODEL'}\n";
-    chdir $model or die;
-
     print "NT: $nt\nDT: $dt\n";
     print "MODEL:\n$pars{'MODEL'}\n";
     print "FLAT: $flat\n";
     print "DEPTH:\n@depth\n";
     print "DIST:\n@dist\n";
-    sleep (10);
+    
+    my $err = 0;
+    my @layer = split m/\n/, $pars{'MODEL'};
+    foreach (@layer) {
+        my $layer = trim($_);
+        my ($dep) = split m/\s+/, $layer;
+        foreach (@depth) {
+            if ($_ == $dep) {
+                print "设置错误：震源在 ${_}km 深度的界面上\n";
+                $err++;
+            }
+        }
+     }
+    if ($err > 0) {
+        print "设置有错误，将导致计算错误，OH MY CAP 中止调用 fk\n";
+        next;
+    }
+    sleep (5);
 
+    mkdir $model unless (-d $model);
+    open (OUT, "> $model/$model") or die;
+    print OUT "$pars{'MODEL'}\n";
+    chdir $model or die;
     foreach my $depth (@depth) {
         $depth = "0$depth" if ($depth < 10);
         if ($flat eq "YES") {

--- a/Glib/run_fk.pl
+++ b/Glib/run_fk.pl
@@ -8,6 +8,7 @@ require config;
 @ARGV >= 1 or die "Usage: perl $0 configname";
 my @config = @ARGV;
 
+my $date = `date`;
 foreach my $fname (@config){
     my %pars = read_config($fname);
     my ($model) = split m/\./, $fname;
@@ -65,3 +66,5 @@ foreach my $fname (@config){
 
     chdir ".." or die;
 }
+print "$date";
+system "date";

--- a/Glib/run_parallel.pl
+++ b/Glib/run_parallel.pl
@@ -60,7 +60,6 @@ foreach my $fname (@config){
     foreach my $depth (@depth) {
         my $pid = $pm -> start and next;
 
-        $depth = "0$depth" if ($depth < 10);
         if ($flat eq "YES") {
             # 计算双力偶
             system "fk_parallel.pl -M$model/$depth/f -N$nt/$dt -S2 @dist";

--- a/Glib/run_parallel.pl
+++ b/Glib/run_parallel.pl
@@ -1,20 +1,24 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use Parallel::ForkManager;
 use FindBin;
 use lib $FindBin::Bin;
+use Sys::CpuAffinity;
+use Parallel::ForkManager;
 require config;
 
 @ARGV >= 1 or die "Usage: perl $0 configname";
 my @config = @ARGV;
 
 # 计算当前计算机逻辑核核数
-my ($MAX_PROCESSES) = split m/\n/, `cat /proc/cpuinfo |grep "processor"|wc -l`;
-# 核数较少的个人 PC 只用一半的核
-$MAX_PROCESSES = int ($MAX_PROCESSES * 0.5) if ($MAX_PROCESSES <= 4);
-# 保证核数至少为 1
-$MAX_PROCESSES = 1 if ($MAX_PROCESSES < 1);
+my $MAX_PROCESSES;
+my ($system) = split m/\s+/, `uname`;
+if ($system eq 'Darwin') {
+    ($MAX_PROCESSES) = split m/\s+/, `sysctl -n hw.ncpu`;
+}elsif ($system eq 'Linux'){
+    ($MAX_PROCESSES) = split m/\n/, `cat /proc/cpuinfo |grep "processor"|wc -l`;
+}
+print "system: $system\nCPU: $MAX_PROCESSES\n";
 
 foreach my $fname (@config){
     my %pars = read_config($fname);

--- a/Glib/run_parallel.pl
+++ b/Glib/run_parallel.pl
@@ -26,17 +26,34 @@ foreach my $fname (@config){
     my $flat = "YES";
     $flat = $pars{"FLAT"} if defined($pars{"FLAT"});
 
-    mkdir $model unless (-d $model);
-    open (OUT, "> $model/$model") or die;
-    print OUT "$pars{'MODEL'}\n";
-    chdir $model or die;
-
     print "NT: $nt\nDT: $dt\n";
     print "MODEL:\n$pars{'MODEL'}\n";
     print "FLAT: $flat\n";
     print "DEPTH:\n@depth\n";
     print "DIST:\n@dist\n";
-    sleep (10);
+
+    my $err = 0;
+    my @layer = split m/\n/, $pars{'MODEL'};
+    foreach (@layer) {
+        my $layer = trim($_);
+        my ($dep) = split m/\s+/, $layer;
+        foreach (@depth) {
+            if ($_ == $dep) {
+                print "设置错误：震源在 ${_}km 深度的界面上\n";
+                $err++;
+            }
+        }
+     }
+    if ($err > 0) {
+        print "设置有错误，将导致计算错误，OH MY CAP 中止调用 fk\n";
+        next;
+    }
+    sleep (5);
+
+    mkdir $model unless (-d $model);
+    open (OUT, "> $model/$model") or die;
+    print OUT "$pars{'MODEL'}\n";
+    chdir $model or die;
 
     # 计算格林函数
     my $pm = Parallel::ForkManager -> new($MAX_PROCESSES);

--- a/example/get_depth.pl
+++ b/example/get_depth.pl
@@ -11,10 +11,16 @@ my @dir = @ARGV;
 foreach my $event (@dir) {
     my %pars = read_config($event);
     chdir "$event" or die "can not open dir $event\n";
-    system "grep -h Event $pars{'MODEL'}_*.out > junk.out";
+    
+    unlink "junk.out" if (-e "junk.out");
+    my @depth = sort { $a <=> $b } split m/\s+/, $pars{'DEPTH'};
+    foreach my $depth (@depth) {
+        system "grep -h Event $pars{'MODEL'}_${depth}.out >> junk.out";
+    }
     system "depth.pl junk.out $event > $pars{'MODEL'}_depth.ps";
     system "ps2raster -A -E1080 -P -Tf $pars{'MODEL'}_depth.ps";
     unlink "$pars{'MODEL'}_depth.ps";
     unlink "junk.out";
+
     chdir "..";
 }

--- a/example/inversion.pl
+++ b/example/inversion.pl
@@ -16,7 +16,6 @@ foreach my $event (@dir){
     # 获取反演的震源深度
     my @depth = split m/\s+/, $pars{'DEPTH'};
     foreach my $depth (@depth) {
-        $depth = "0$depth" if $depth < 10;
         # deal with -M option
         my $cap_args = "$pars{'cap_args'} -M$pars{'MODEL'}_${depth}/$pars{'MAG'}";
         print "cap.pl $cap_args $event\n";


### PR DESCRIPTION
1. 忽略自定义文件

考虑到可能需要在工作区内放置一些文件，比如自己写的脚本，而又不想加入 repo 中，可以用 i_ 开头，则会忽略

2. 添加检查震源深度和界面深度是否一样的功能

震源深度不能等于界面深度。添加检查这一点的功能

3. 彻底解决 grep 排序不当造成 gmt 绘图脚本确定图幅范围出错的bug

Prof. Zhu 的画深度-拟合残差图的 gmt4 脚本不能正确确定图幅范围。
原因在于它要求它所依赖的 junk.out 文件中的各个深度的记录必须是升序，而生成 junk.out 文件的 grep 是按 ASCII 顺序排序而不是数值大小。
之前的做法是小于 10 的深度前面加一个 0，但是这样不符合人类习惯，特别是在深度为小于 1 的小数时让人觉得非常奇怪。
现在改用 Perl 脚本来完成排序的事情，再依次交给 grep，既不会出现错误，又符合人类习惯，彻底解决此 bug。

4. 修改获取计算机逻辑核数目的方式

之前的方式依赖系统特性，只适用于 Linux，为了同时适应 Mac，增加功能：判断系统类别，再针对不同系统得到计算机逻辑核数目

5. 给 example/marktime.pl 添加注释